### PR TITLE
allow spaces in JUPYTER_GAP_EXECUTABLE

### DIFF
--- a/etc/jupyter/jupyter-kernel-gap
+++ b/etc/jupyter/jupyter-kernel-gap
@@ -2,10 +2,10 @@
 
 GAP=`which gap`
 
-if [ x$GAP == x ] ; then
+if [ "x$GAP" == "x" ] ; then
   GAP=$JUPYTER_GAP_EXECUTABLE
 fi
-if [ x$GAP == x ] ; then
+if [ "x$GAP" == "x" ] ; then
   echo "Error: No executable GAP found"
   exit
 fi


### PR DESCRIPTION
This makes jupyter-kernel-gap work when, for example, JUPYTER_GAP_EXECUTABLE is set to `gap -r -A`