### PR TITLE
Update bin/jupyter-kernel-gap

### DIFF
--- a/bin/jupyter-kernel-gap
+++ b/bin/jupyter-kernel-gap
@@ -1,18 +1,13 @@
 #!/bin/sh
 
-if [ -z "$GAP" ] ; then
+if [ -n "$JUPYTER_GAP_EXECUTABLE" ] ; then
   GAP=$JUPYTER_GAP_EXECUTABLE
-fi;
-if [ -z "$GAP" ] ; then
-  GAP=`which gap`
-fi
-if [ -z "$GAP" ] ; then
-  echo "Error: No executable GAP found"
-  exit
+elif [ -z "$GAP" ] ; then
+  GAP=gap
 fi
 
 echo "GAP Jupyter Kernel Starting using $GAP"
-$GAP -q -T <<EOF
+exec $GAP -q -T <<EOF
    LoadPackage("JupyterKernel");
    JUPYTER_KernelStart_GAP("$1");
    QUIT_GAP(0);


### PR DESCRIPTION
To find GAP, we now proceed as follows: First, if $JUPYTER_GAP_EXECUTABLE is
set, we use that. If not, then we check if $GAP is set and use that. If not,
we try to use `gap` in the current path.

Also avoid the use of `which`, which is non-standard. Instead, just hard code
the name `gap`, and don't bother performing any further checks (we don't
validate the value of $JUPYTER_GAP_EXECUTABLE or $GAP either)

Finally, use `exec` to start GAP, replacing the shell, instead of creating
a fresh process.

The script now passes the tests on https://www.shellcheck.net
