### PR TITLE
Adapt use of ERROR_OUTPUT

### DIFF
--- a/gap/JupyterKernel.gi
+++ b/gap/JupyterKernel.gi
@@ -315,7 +315,10 @@ function(conf)
         # TODO: This is of course still hacky, but better than before
         kernel!.StdOut := OutputStreamZmq(kernel, kernel!.IOPub);
         kernel!.StdErr := OutputStreamZmq(kernel, kernel!.IOPub, "stderr");
+        # TODO: Hack to be able to change ERROR_OUTPUT.
+        MakeReadWriteGlobal("ERROR_OUTPUT");
         ERROR_OUTPUT := kernel!.StdErr;
+        MakeReadOnlyGlobal("ERROR_OUTPUT");
         OutputLogTo(kernel!.StdOut);
 
         # Jupyter Heartbeat and Control channel is handled by a fork'ed GAP process


### PR DESCRIPTION
ERROR_OUTPUT was made a read-only global variable. But we
still want to change it.