### PR TITLE
Do not run protocol.tst as a part of the default test

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -96,7 +96,7 @@ Dependencies := rec(
 
 AvailabilityTest := ReturnTrue,
 
-TestFile := "tst/testall.g",
+TestFile := "tst/basic.tst",
 
 Keywords := [ "Jupyter", "User Interface" ],
 


### PR DESCRIPTION
We will continue to run it on Travis CI, but not as a part of the
test specified in PackageInfo.g file. The reason for this is that
IO_Fork creates two processes running the same test, and then both
indicate that the test has been completed, confusing tests of the
GAP release candidate.