### PR TITLE
Make default test more robust and easy to extend

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -97,7 +97,7 @@ Dependencies := rec(
 
 AvailabilityTest := ReturnTrue,
 
-TestFile := "tst/basic.tst",
+TestFile := "tst/testinstall.g",
 
 Keywords := [ "Jupyter", "User Interface" ],
 

--- a/tst/testinstall.g
+++ b/tst/testinstall.g
@@ -1,0 +1,15 @@
+#
+# JupyterKernel: Jupyter kernel using ZeroMQ
+#
+# This file runs package tests. It is also referenced in the package
+# metadata in PackageInfo.g.
+#
+LoadPackage( "JupyterKernel" );
+
+TestDirectory( DirectoriesPackageLibrary("JupyterKernel", "tst"),
+            rec(exitGAP     := true, 
+                exclude     := [ "protocol.tst" ],
+                testOptions := rec(compareFunction := "uptowhitespace") ) );
+
+# Should never get here
+FORCE_QUIT_GAP(1);


### PR DESCRIPTION
This excludes `protocol.tst` from the test that is specified in `PackageInfo.g`. 