### PR TITLE
prefer `ViewObj` to `ViewString` (temporarily)

### DIFF
--- a/gap/JupyterRenderable.gi
+++ b/gap/JupyterRenderable.gi
@@ -3,7 +3,9 @@ InstallMethod( JupyterRender, "default fallback"
              , [ IsObject ],
 function(obj)
     local str;
-    str := ViewString(obj);
+    # Use the strings corresponding to 'ViewObj'
+    # until enough 'ViewString' methods are available.
+    str := StringView(obj);
     RemoveCharacters(str, "\<\>\n");
     return Objectify( JupyterRenderableType
                     , rec( data := rec( text\/plain := str )


### PR DESCRIPTION
In `JupyterRender`, call `StringView` (which is based on `ViewObj`) instead of `ViewString` (for which many methods are missing).
This makes GAP's Jupyter kernel more useful.
Here is a typical example.

````
gap> obj:= End( GF(2), GF(2)^2 );
End( GF(2), ( GF(2)^2 ) )
gap> ViewString( obj );
"<monoid>"
gap> StringView( obj );
"End( GF(2), ( GF(2)^2 ) )"
```