### PR TITLE
Fix Multiple top-level packages error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,5 @@ setuptools.setup(
     zip_safe=False,
     # Require notebook>=5.3 for automatically enabling the nbextension
     install_requires=['notebook>=5.3'],
+    packages=[],
 )


### PR DESCRIPTION
Installing the python package via `pip install .` was giving me the error `Multiple top-level packages discovered in a flat-layout: ['tst', 'etc', 'gap', 'demos'].`.

Here are the versions my things
```
❯ python --version
Python 3.10.8
❯ pip --version
pip 22.3.1 from /usr/lib/python3.10/site-packages/pip (python 3.10)
❯ pip show setuptools
Name: setuptools
Version: 65.2.0
Summary: Easily download, build, install, upgrade, and uninstall Python packages
Home-page: https://github.com/pypa/setuptools
Author: Python Packaging Authority
Author-email: distutils-sig@python.org
License:
Location: /usr/lib/python3.10/site-packages
Requires: appdirs, jaraco.text, more-itertools, ordered-set, packaging, pyparsing, tomli, validate-pyproject
Required-by: jupyter_packaging
```