### PR TITLE
Don't use bin/gap.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ your path.
 
 This can be done through symlinking:
 
-    sudo ln -s <GAP-installation-directory>/bin/gap.sh gap
+    sudo ln -s <GAP-installation-directory>/gap gap
   
     sudo ln -s <GAP-installation-directory>/pkg/JupyterKernel-X.Y.Z/bin/jupyter-kernel-gap
 


### PR DESCRIPTION
GAP only provides it for backwards compatibility with old GAP versions.
Since GAP 4.9 one should instead just call the gap binary directly.
