### PR TITLE
Remove invalid 'ReadPackage' calls to removed files

### DIFF
--- a/init.g
+++ b/init.g
@@ -4,14 +4,10 @@
 # Reading the declaration part of the package.
 #
 
-# HACK
-ReadPackage( "JupyterKernel", "gap/JupyterError.gi");
 
 ReadPackage( "JupyterKernel", "gap/JupyterStream.gd");
 ReadPackage( "JupyterKernel", "gap/JupyterMsg.gd");
-ReadPackage( "JupyterKernel", "gap/JupyterHB.gd");
 ReadPackage( "JupyterKernel", "gap/JupyterKernel.gd");
-ReadPackage( "JupyterKernel", "gap/JupyterJson.gd");
 ReadPackage( "JupyterKernel", "gap/JupyterHelp.gd");
 ReadPackage( "JupyterKernel", "gap/JupyterUtil.gd");
 ReadPackage( "JupyterKernel", "gap/JupyterRenderable.gd");

--- a/read.g
+++ b/read.g
@@ -5,9 +5,7 @@
 #
 ReadPackage( "JupyterKernel", "gap/JupyterStream.gi");
 ReadPackage( "JupyterKernel", "gap/JupyterMsg.gi");
-ReadPackage( "JupyterKernel", "gap/JupyterHB.gi");
 ReadPackage( "JupyterKernel", "gap/JupyterKernel.gi");
-ReadPackage( "JupyterKernel", "gap/JupyterJson.gi");
 ReadPackage( "JupyterKernel", "gap/JupyterUtil.gi");
 ReadPackage( "JupyterKernel", "gap/JupyterHelp.gi");
 ReadPackage( "JupyterKernel", "gap/JupyterCompletion.gi");


### PR DESCRIPTION
I checked, and each of these files was removed at some point, but the 'ReadPackage' calls were not removed when the file was.